### PR TITLE
fix: use the path of the tree view's selected project as the terminal cwd

### DIFF
--- a/spec/model-spec.js
+++ b/spec/model-spec.js
@@ -96,39 +96,72 @@ describe('XTerminalModel', () => {
 		expect(model.getPath()).toBe(configDefaults.cwd)
 	})
 
-	it('constructor with previous active item that has getPath() method', async () => {
-		const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
-		previousActiveItem.getPath.and.returnValue(tmpdir)
+  it('constructor with previous active item that has getPath() method', async () => {
+    const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
+    previousActiveItem['getPath'].and.returnValue(tmpdir)
+    spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
+		const model = await createNewModel({ projectCwd: true })
+		expect(model.getPath()).toBe(tmpdir)
+	})
+
+	it('constructor with previous active item that has selectedPath property', async () => {
+    const previousActiveItem = jasmine.createSpyObj('somemodel', {}, { ['selectedPath']: '' })
+		Object.getOwnPropertyDescriptor(previousActiveItem, 'selectedPath').get.and.returnValue(tmpdir)
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
 		const model = await createNewModel({ projectCwd: true })
 		expect(model.getPath()).toBe(tmpdir)
 	})
 
-	it('constructor with previous active item that has getPath() method returns file path', async () => {
-		const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
+	it('constructor with previous active item that has getPath() method that returns file path', async () => {
+    const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
 		const filePath = path.join(tmpdir, 'somefile')
 		await fs.writeFile(filePath, '')
-		previousActiveItem.getPath.and.returnValue(filePath)
+		previousActiveItem['getPath'].and.returnValue(filePath)
+		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
+		const model = await createNewModel({ projectCwd: true })
+		expect(model.getPath()).toBe(tmpdir)
+	})
+
+	it('constructor with previous active item that has selectedPath() property that returns file path', async () => {
+    const previousActiveItem = jasmine.createSpyObj('somemodel', {}, { ['selectedPath']: '' })
+		const filePath = path.join(tmpdir, 'somefile')
+		await fs.writeFile(filePath, '')
+		Object.getOwnPropertyDescriptor(previousActiveItem, 'selectedPath').get.and.returnValue(filePath)
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
 		const model = await createNewModel({ projectCwd: true })
 		expect(model.getPath()).toBe(tmpdir)
 	})
 
 	it('constructor with previous active item that has getPath() returning invalid path', async () => {
-		const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
-		previousActiveItem.getPath.and.returnValue(path.join(tmpdir, 'non-existent-dir'))
+    const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
+		previousActiveItem['getPath'].and.returnValue(path.join(tmpdir, 'non-existent-dir'))
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
 		const model = await createNewModel({ projectCwd: true })
 		expect(model.getPath()).toBe(configDefaults.cwd)
 	})
 
-	it('constructor with previous active item which exists in project path', async () => {
-		const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
+	it('constructor with previous active item that has selectedPath returning invalid path', async () => {
+    const previousActiveItem = jasmine.createSpyObj('somemodel', {}, { ['selectedPath']: '' })
+		Object.getOwnPropertyDescriptor(previousActiveItem, 'selectedPath').get.and.returnValue(path.join(tmpdir, 'non-existent-dir'))
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
-		const expected = ['/some/dir', null]
-		spyOn(atom.project, 'relativizePath').and.returnValue(expected)
 		const model = await createNewModel({ projectCwd: true })
-		expect(model.getPath()).toBe(expected[0])
+		expect(model.getPath()).toBe(configDefaults.cwd)
+	})
+
+	it('constructor with previous active item which exists in project path and calls getPath', async () => {
+    const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
+		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
+		spyOn(atom.project, 'relativizePath').and.returnValue(['/some/dir', null])
+		const model = await createNewModel({ projectCwd: true })
+		expect(model.getPath()).toBe('/some/dir')
+	})
+
+	it('constructor with previous active item which exists in project path and calls selectedPath', async () => {
+    const previousActiveItem = jasmine.createSpyObj('somemodel', {}, { ['selectedPath']: '' })
+		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
+		spyOn(atom.project, 'relativizePath').and.returnValue(['/some/dir', null])
+		const model = await createNewModel({ projectCwd: true })
+		expect(model.getPath()).toBe('/some/dir')
 	})
 
 	it('constructor with custom title', async () => {

--- a/src/model.js
+++ b/src/model.js
@@ -75,12 +75,19 @@ class XTerminalModel {
 	async initialize () {
 		let cwd
 
-		if (this.uriCwd) {
+    if (this.uriCwd) {
 			cwd = this.uriCwd
 		} else if (this.profile.projectCwd) {
 			const previousActiveItem = atom.workspace.getActivePaneItem()
 			if (typeof previousActiveItem !== 'undefined' && typeof previousActiveItem.getPath === 'function') {
 				cwd = previousActiveItem.getPath()
+				const dir = atom.project.relativizePath(cwd)[0]
+				if (dir) {
+					this.profile.cwd = dir
+					return
+				}
+			} else if (typeof previousActiveItem !== 'undefined' && typeof previousActiveItem.selectedPath === 'string') {
+				cwd = previousActiveItem.selectedPath
 				const dir = atom.project.relativizePath(cwd)[0]
 				if (dir) {
 					this.profile.cwd = dir


### PR DESCRIPTION
### Identify the Bug

https://github.com/Spiker985/x-terminal-reloaded/issues/50

### Description of the Change

- use selectedPath to set cwd when you can't find a path using getPath, which is the case when tree view is the atom.workspace.getActivePaneItem()

### Verification Process

Added tests, used for a while, was similar in atomic-terminal and fixed with https://github.com/atom-community/terminal/pull/102

### Release Notes

- pwd of terminal opened with x-terminal-reloaded:open is now the path of the selected project when tree-view is active

