### PR TITLE
feat: Add configuration for Terminal Notifications

### DIFF
--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -1969,6 +1969,20 @@ describe('XTerminalElement', () => {
 		expect(atom.notifications.addSuccess).toHaveBeenCalled()
 	})
 
+	function givenShowNotificationsFalse () {
+		element.model.profile.showNotifications = false
+	}
+
+	it('showNotification() success message with Atom notification disabled', () => {
+		givenShowNotificationsFalse()
+		spyOn(atom.notifications, 'addSuccess')
+		element.showNotification(
+			'foo',
+			'success',
+		)
+		expect(atom.notifications.addSuccess).not.toHaveBeenCalled()
+	})
+
 	it('showNotification() error message with Atom notification', () => {
 		spyOn(atom.notifications, 'addError')
 		element.showNotification(
@@ -1976,6 +1990,16 @@ describe('XTerminalElement', () => {
 			'error',
 		)
 		expect(atom.notifications.addError).toHaveBeenCalled()
+	})
+
+	it('showNotification() error message with Atom notification disabled', () => {
+		givenShowNotificationsFalse()
+		spyOn(atom.notifications, 'addError')
+		element.showNotification(
+			'foo',
+			'error',
+		)
+		expect(atom.notifications.addError).not.toHaveBeenCalled()
 	})
 
 	it('showNotification() warning message with Atom notification', () => {
@@ -1987,6 +2011,16 @@ describe('XTerminalElement', () => {
 		expect(atom.notifications.addWarning).toHaveBeenCalled()
 	})
 
+	it('showNotification() warning message with Atom notification disabled', () => {
+		givenShowNotificationsFalse()
+		spyOn(atom.notifications, 'addWarning')
+		element.showNotification(
+			'foo',
+			'warning',
+		)
+		expect(atom.notifications.addWarning).not.toHaveBeenCalled()
+	})
+
 	it('showNotification() info message with Atom notification', () => {
 		spyOn(atom.notifications, 'addInfo')
 		element.showNotification(
@@ -1994,6 +2028,16 @@ describe('XTerminalElement', () => {
 			'info',
 		)
 		expect(atom.notifications.addInfo).toHaveBeenCalled()
+	})
+
+	it('showNotification() info message with Atom notification disabled', () => {
+		givenShowNotificationsFalse()
+		spyOn(atom.notifications, 'addInfo')
+		element.showNotification(
+			'foo',
+			'info',
+		)
+		expect(atom.notifications.addInfo).not.toHaveBeenCalled()
 	})
 
 	it('showNotification() bogus info type with Atom notification', () => {
@@ -2004,6 +2048,17 @@ describe('XTerminalElement', () => {
 			)
 		}
 		expect(call).toThrow(new Error('Unknown info type: bogus'))
+	})
+
+	it('showNotification() bogus info type with Atom notification disabled', () => {
+		givenShowNotificationsFalse()
+		const call = () => {
+			element.showNotification(
+				'foo',
+				'bogus',
+			)
+		}
+		expect(call).not.toThrow(new Error('Unknown info type: bogus'))
 	})
 
 	it('showNotification() custom restart button text', () => {

--- a/spec/profiles-spec.js
+++ b/spec/profiles-spec.js
@@ -78,6 +78,7 @@ describe('XTerminalProfilesSingleton', () => {
 			},
 			promptToStartup: false,
 			copyOnSelect: false,
+			showNotifications: true,
 			webgl: true,
 			webLinks: false,
 		}
@@ -104,6 +105,7 @@ describe('XTerminalProfilesSingleton', () => {
 		url.searchParams.set('xtermOptions', JSON.stringify(defaultProfile.xtermOptions))
 		url.searchParams.set('promptToStartup', JSON.stringify(defaultProfile.promptToStartup))
 		url.searchParams.set('copyOnSelect', JSON.stringify(defaultProfile.copyOnSelect))
+		url.searchParams.set('showNotifications', JSON.stringify(defaultProfile.showNotifications))
 		url.searchParams.set('webgl', defaultProfile.webgl)
 		url.searchParams.set('webLinks', defaultProfile.webLinks)
 		return url
@@ -236,6 +238,9 @@ describe('XTerminalProfilesSingleton', () => {
 			return true
 		}
 		if (key === 'x-terminal-reloaded.terminalSettings.copyOnSelect') {
+			return true
+		}
+		if (key === 'x-terminal.terminalSettings.showNotifications') {
 			return true
 		}
 		if (key === 'x-terminal-reloaded.xtermAddons.webgl') {
@@ -381,6 +386,7 @@ describe('XTerminalProfilesSingleton', () => {
 			xtermOptions: JSON.parse(atom.config.get('x-terminal-reloaded.terminalSettings.xtermOptions') || configDefaults.xtermOptions),
 			promptToStartup: atom.config.get('x-terminal-reloaded.terminalSettings.promptToStartup') || configDefaults.promptToStartup,
 			copyOnSelect: atom.config.get('x-terminal-reloaded.terminalSettings.copyOnSelect') || configDefaults.copyOnSelect,
+			showNotifications: atom.config.get('x-terminal.terminalSettings.showNotifications') || configDefaults.showNotifications,
 			webgl: atom.config.get('x-terminal-reloaded.xtermAddons.webgl') || configDefaults.webgl,
 			webLinks: atom.config.get('x-terminal-reloaded.xtermAddons.webLinks') || configDefaults.webLinks,
 		}
@@ -435,6 +441,7 @@ describe('XTerminalProfilesSingleton', () => {
 			},
 			promptToStartup: true,
 			copyOnSelect: true,
+			showNotifications: true,
 			webgl: true,
 			webLinks: false,
 		}
@@ -585,8 +592,9 @@ describe('XTerminalProfilesSingleton', () => {
 			title: '',
 			promptToStartup: false,
 			copyOnSelect: false,
+			showNotifications: true,
 		}
-		const expected = 'args=%5B%5D&command=somecommand&copyOnSelect=false&cwd=%2Fsome%2Fpath&deleteEnv=%5B%5D&encoding=&env=null&fontSize=14&leaveOpenAfterExit=true&name=sometermtype&promptToStartup=false&relaunchTerminalOnStartup=true&setEnv=%7B%7D&title='
+		const expected = 'args=%5B%5D&command=somecommand&copyOnSelect=false&cwd=%2Fsome%2Fpath&deleteEnv=%5B%5D&encoding=&env=null&fontSize=14&leaveOpenAfterExit=true&name=sometermtype&promptToStartup=false&relaunchTerminalOnStartup=true&setEnv=%7B%7D&showNotifications=true&title='
 		const url = XTerminalProfilesSingleton.instance.generateNewUrlFromProfileData(data)
 		url.searchParams.sort()
 		expect(url.searchParams.toString()).toBe(expected)
@@ -611,13 +619,14 @@ describe('XTerminalProfilesSingleton', () => {
 			},
 			promptToStartup: false,
 			copyOnSelect: false,
+			showNotifications: true,
 		}
 		const data = {
 			...validData,
 			foo: 'bar',
 			baz: null,
 		}
-		const expected = 'args=%5B%5D&command=somecommand&copyOnSelect=false&cwd=%2Fsome%2Fpath&deleteEnv=%5B%5D&encoding=&env=null&fontSize=14&leaveOpenAfterExit=true&name=sometermtype&promptToStartup=false&relaunchTerminalOnStartup=true&setEnv=%7B%7D&title=&xtermOptions=%7B%22cursorBlink%22%3Atrue%7D'
+		const expected = 'args=%5B%5D&command=somecommand&copyOnSelect=false&cwd=%2Fsome%2Fpath&deleteEnv=%5B%5D&encoding=&env=null&fontSize=14&leaveOpenAfterExit=true&name=sometermtype&promptToStartup=false&relaunchTerminalOnStartup=true&setEnv=%7B%7D&showNotifications=true&title=&xtermOptions=%7B%22cursorBlink%22%3Atrue%7D'
 		const url = XTerminalProfilesSingleton.instance.generateNewUrlFromProfileData(data)
 		url.searchParams.sort()
 		expect(url.searchParams.toString()).toEqual(expected)
@@ -668,6 +677,7 @@ describe('XTerminalProfilesSingleton', () => {
 			xtermOptions: JSON.parse(configDefaults.xtermOptions),
 			promptToStartup: configDefaults.promptToStartup,
 			copyOnSelect: configDefaults.copyOnSelect,
+			showNotifications: configDefaults.showNotifications,
 			webgl: configDefaults.webgl,
 			webLinks: configDefaults.webLinks,
 		}
@@ -937,6 +947,20 @@ describe('XTerminalProfilesSingleton', () => {
 		expect(XTerminalProfilesSingleton.instance.createProfileDataFromUri(url.href)).toEqual(expected)
 	})
 
+	it('createProfileDataFromUri() URI showNotifications set to null', () => {
+		const url = getDefaultExpectedUrl()
+		url.searchParams.set('showNotifications', null)
+		const expected = getDefaultExpectedProfile()
+		expect(XTerminalProfilesSingleton.instance.createProfileDataFromUri(url.href)).toEqual(expected)
+	})
+
+	it('createProfileDataFromUri() URI showNotifications set to empty string', () => {
+		const url = getDefaultExpectedUrl()
+		url.searchParams.set('showNotifications', '')
+		const expected = getDefaultExpectedProfile()
+		expect(XTerminalProfilesSingleton.instance.createProfileDataFromUri(url.href)).toEqual(expected)
+	})
+
 	it('diffProfiles() no change between objects', () => {
 		const baseProfile = XTerminalProfilesSingleton.instance.getBaseProfile()
 		const expected = {}
@@ -1054,6 +1078,7 @@ describe('XTerminalProfilesSingleton', () => {
 			xtermOptions: JSON.parse(configDefaults.xtermOptions),
 			promptToStartup: configDefaults.promptToStartup,
 			copyOnSelect: configDefaults.copyOnSelect,
+			showNotifications: configDefaults.showNotifications,
 			webgl: configDefaults.webgl,
 			webLinks: configDefaults.webLinks,
 		}

--- a/src/config.js
+++ b/src/config.js
@@ -86,6 +86,7 @@ export function resetConfigDefaults () {
 		xtermOptions: '{}',
 		promptToStartup: false,
 		copyOnSelect: false,
+		showNotifications: true,
 		apiOpenPosition: 'Center',
 	}
 }
@@ -494,6 +495,21 @@ export const config = configOrder({
 					fromUrlParam: (val) => JSON.parse(val),
 					checkUrlParam: (val) => (val !== null && val !== ''),
 					toBaseProfile: (previousValue) => validateBooleanConfigSetting('x-terminal-reloaded.terminalSettings.copyOnSelect', configDefaults.copyOnSelect),
+					fromMenuSetting: (element, baseValue) => element.checked,
+					toMenuSetting: (val) => val,
+				},
+			},
+			showNotifications: {
+				title: 'Show notifications',
+				description: 'Show terminal process exit success and failure notifications',
+				type: 'boolean',
+				default: configDefaults.showNotifications,
+				profileData: {
+					defaultProfile: configDefaults.showNotifications,
+					toUrlParam: (val) => JSON.stringify(val),
+					fromUrlParam: (val) => JSON.parse(val),
+					checkUrlParam: (val) => (val !== null && val !== ''),
+					toBaseProfile: (previousValue) => validateBooleanConfigSetting('x-terminal.terminalSettings.showNotifications', configDefaults.showNotifications),
 					fromMenuSetting: (element, baseValue) => element.checked,
 					toMenuSetting: (val) => val,
 				},

--- a/src/element.js
+++ b/src/element.js
@@ -542,16 +542,18 @@ class XTerminalElementImpl extends HTMLElement {
 		messageDiv.appendChild(restartButton)
 		this.topDiv.innerHTML = ''
 		this.topDiv.appendChild(messageDiv)
-		if (infoType === 'success') {
-			atom.notifications.addSuccess(message)
-		} else if (infoType === 'error') {
-			atom.notifications.addError(message)
-		} else if (infoType === 'warning') {
-			atom.notifications.addWarning(message)
-		} else if (infoType === 'info') {
-			atom.notifications.addInfo(message)
-		} else {
-			throw new Error('Unknown info type: ' + infoType)
+		if (this.model.profile.showNotifications) {
+			if (infoType === 'success') {
+				atom.notifications.addSuccess(message)
+			} else if (infoType === 'error') {
+				atom.notifications.addError(message)
+			} else if (infoType === 'warning') {
+				atom.notifications.addWarning(message)
+			} else if (infoType === 'info') {
+				atom.notifications.addInfo(message)
+			} else {
+				throw new Error('Unknown info type: ' + infoType)
+			}
 		}
 	}
 


### PR DESCRIPTION
Added a configuration to disable/enable the terminal process exit status notifications, defaulted to enabled, been using for a while now and seems good.

For context my terminal lets me know about process exit status, so don't feel I need a notification, also I use [atom-project-manager](https://github.com/danielbrodin/atom-project-manager) and would get a failure notification whenever I changed project and had a terminal open, which was bugging me.

If it sounds good please merge in, thanks!

![Screenshot_2023-10-08_09-19-02](https://github.com/Spiker985/x-terminal-reloaded/assets/899951/6975ff70-b3c1-48ad-8855-a397d7524daf)

